### PR TITLE
Add alternate_title field to hero/banner block, update template

### DIFF
--- a/home/blocks.py
+++ b/home/blocks.py
@@ -5,6 +5,7 @@ import feedparser
 
 class HeroBlock(blocks.StructBlock):
     subject = blocks.CharBlock(required=False)
+    alternate_title = blocks.CharBlock(required=False)
     class Meta:
         icon = "placeholder"
         template = "home/blocks/hero.html"
@@ -39,4 +40,4 @@ class RSSBlock(blocks.StructBlock):
 
     class Meta:
         icon = "code"
-        template = "home/blocks/rss_feed.html"   
+        template = "home/blocks/rss_feed.html"

--- a/home/templates/home/blocks/hero.html
+++ b/home/templates/home/blocks/hero.html
@@ -4,7 +4,11 @@
             <span class="hero-subject">{{ value.subject }}</span>
         </div>
         <div class="row justify-content-start">
+        {% if value.alternate_title %}
+            <span class="hero-title">{{ value.alternate_title }}</span>
+        {% else %}
             <span class="hero-title">{{ title }}</span>
+        {% endif %}
         </div>
         <div class="row justify-content-start">
             <span class="hero-byline">{{ subtitle }}</span>


### PR DESCRIPTION
- @5arias, we should consider making the hero/banner `subject` required as it doesn't make much sense to include a banner with completely empty fields